### PR TITLE
Fix/empty labelselector

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -130,6 +130,7 @@ func buildRequirements(in *v1beta1.Input, xr *resource.Composite) (*fnv1beta1.Re
 				},
 			}
 		case v1beta1.ResourceSourceTypeSelector:
+			containsMissingOptionalField := false
 			matchLabels := map[string]string{}
 			for _, selector := range extraResource.Selector.MatchLabels {
 				switch selector.GetType() {
@@ -142,12 +143,13 @@ func buildRequirements(in *v1beta1.Input, xr *resource.Composite) (*fnv1beta1.Re
 						if !selector.FromFieldPathIsOptional() {
 							return nil, errors.Wrapf(err, "cannot get value from field path %q", *selector.ValueFromFieldPath)
 						}
+						containsMissingOptionalField = true
 						continue
 					}
 					matchLabels[selector.Key] = value
 				}
 			}
-			if len(matchLabels) == 0 {
+			if len(matchLabels) == 0 && containsMissingOptionalField {
 				continue
 			}
 			extraResources[extraResName] = &fnv1beta1.ResourceSelector{

--- a/fn.go
+++ b/fn.go
@@ -130,38 +130,48 @@ func buildRequirements(in *v1beta1.Input, xr *resource.Composite) (*fnv1beta1.Re
 				},
 			}
 		case v1beta1.ResourceSourceTypeSelector:
-			containsMissingOptionalField := false
-			matchLabels := map[string]string{}
-			for _, selector := range extraResource.Selector.MatchLabels {
-				switch selector.GetType() {
-				case v1beta1.ResourceSourceSelectorLabelMatcherTypeValue:
-					// TODO validate value not to be nil
-					matchLabels[selector.Key] = *selector.Value
-				case v1beta1.ResourceSourceSelectorLabelMatcherTypeFromCompositeFieldPath:
-					value, err := fieldpath.Pave(xr.Resource.Object).GetString(*selector.ValueFromFieldPath)
-					if err != nil {
-						if !selector.FromFieldPathIsOptional() {
-							return nil, errors.Wrapf(err, "cannot get value from field path %q", *selector.ValueFromFieldPath)
-						}
-						containsMissingOptionalField = true
-						continue
-					}
-					matchLabels[selector.Key] = value
-				}
+			out, err := buildTypeSelectorRequirement(xr, extraResource)
+			if err != nil {
+				return nil, err
 			}
-			if len(matchLabels) == 0 && containsMissingOptionalField {
-				continue
-			}
-			extraResources[extraResName] = &fnv1beta1.ResourceSelector{
-				ApiVersion: extraResource.APIVersion,
-				Kind:       extraResource.Kind,
-				Match: &fnv1beta1.ResourceSelector_MatchLabels{
-					MatchLabels: &fnv1beta1.MatchLabels{Labels: matchLabels},
-				},
+			if out != nil {
+				extraResources[extraResName] = out
 			}
 		}
 	}
 	return &fnv1beta1.Requirements{ExtraResources: extraResources}, nil
+}
+
+func buildTypeSelectorRequirement(xr *resource.Composite, extraResource v1beta1.ResourceSource) (*fnv1beta1.ResourceSelector, error) {
+	containsMissingOptionalField := false
+	matchLabels := map[string]string{}
+	for _, selector := range extraResource.Selector.MatchLabels {
+		switch selector.GetType() {
+		case v1beta1.ResourceSourceSelectorLabelMatcherTypeValue:
+			// TODO validate value not to be nil
+			matchLabels[selector.Key] = *selector.Value
+		case v1beta1.ResourceSourceSelectorLabelMatcherTypeFromCompositeFieldPath:
+			value, err := fieldpath.Pave(xr.Resource.Object).GetString(*selector.ValueFromFieldPath)
+			if err != nil {
+				if !selector.FromFieldPathIsOptional() {
+					return nil, errors.Wrapf(err, "cannot get value from field path %q", *selector.ValueFromFieldPath)
+				}
+				containsMissingOptionalField = true
+				continue
+			}
+			matchLabels[selector.Key] = value
+		}
+	}
+	if len(matchLabels) == 0 && containsMissingOptionalField {
+		return nil, nil
+	}
+	return &fnv1beta1.ResourceSelector{
+		ApiVersion: extraResource.APIVersion,
+		Kind:       extraResource.Kind,
+		Match: &fnv1beta1.ResourceSelector_MatchLabels{
+			MatchLabels: &fnv1beta1.MatchLabels{Labels: matchLabels},
+		},
+	}, nil
 }
 
 // Verify Min/Max and sort extra resources by field path within a single kind.

--- a/fn.go
+++ b/fn.go
@@ -199,13 +199,13 @@ func verifyAndSortExtras(in *v1beta1.Input, extraResources map[string][]resource
 
 		case v1beta1.ResourceSourceTypeSelector:
 			selector := extraResource.Selector
-			if selector.MinMatch != nil && len(resources) < int(*selector.MinMatch) {
+			if selector.MinMatch != nil && uint64(len(resources)) < *selector.MinMatch {
 				return nil, errors.Errorf("expected at least %d extra resources %q, got %d", *selector.MinMatch, extraResName, len(resources))
 			}
 			if err := sortExtrasByFieldPath(resources, selector.GetSortByFieldPath()); err != nil {
 				return nil, err
 			}
-			if selector.MaxMatch != nil && len(resources) > int(*selector.MaxMatch) {
+			if selector.MaxMatch != nil && uint64(len(resources)) > *selector.MaxMatch {
 				resources = resources[:*selector.MaxMatch]
 			}
 			for _, r := range resources {

--- a/fn_test.go
+++ b/fn_test.go
@@ -119,6 +119,15 @@ func TestRunFunction(t *testing.T) {
 											}
 										]
 									}
+								},
+								{
+									"type": "Selector",
+									"kind": "EnvironmentConfig",
+									"apiVersion": "apiextensions.crossplane.io/v1alpha1",
+									"into": "obj-5",
+									"selector": {
+										"matchLabels": []
+									}
 								}
 							]
 						}
@@ -167,6 +176,15 @@ func TestRunFunction(t *testing.T) {
 										Labels: map[string]string{
 											"someMoreFoo": "someMoreBar",
 										},
+									},
+								},
+							},
+							"obj-5": {
+								ApiVersion: "apiextensions.crossplane.io/v1alpha1",
+								Kind:       "EnvironmentConfig",
+								Match: &fnv1beta1.ResourceSelector_MatchLabels{
+									MatchLabels: &fnv1beta1.MatchLabels{
+										Labels: map[string]string{},
 									},
 								},
 							},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Currently the function does NOT request a resource when a fieldPath was specified as optional and no other labels have been chosen.

This specifically intended behaviour is kept and a flag is added which tracks if optional fields were not found.

If not the matchLabels is added even if it is empty.

Also an appropriate test was added

Fixes #21 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
