### PR TITLE
Allow querying resources without labels

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -131,6 +131,7 @@ func buildRequirements(in *v1beta1.Input, xr *resource.Composite) (*fnv1beta1.Re
 			}
 		case v1beta1.ResourceSourceTypeSelector:
 			matchLabels := map[string]string{}
+			hasOptionalSelector := false
 			for _, selector := range extraResource.Selector.MatchLabels {
 				switch selector.GetType() {
 				case v1beta1.ResourceSourceSelectorLabelMatcherTypeValue:
@@ -142,12 +143,13 @@ func buildRequirements(in *v1beta1.Input, xr *resource.Composite) (*fnv1beta1.Re
 						if !selector.FromFieldPathIsOptional() {
 							return nil, errors.Wrapf(err, "cannot get value from field path %q", *selector.ValueFromFieldPath)
 						}
+						hasOptionalSelector = true
 						continue
 					}
 					matchLabels[selector.Key] = value
 				}
 			}
-			if len(matchLabels) == 0 {
+			if hasOptionalSelector && len(matchLabels) == 0 {
 				continue
 			}
 			extraResources[extraResName] = &fnv1beta1.ResourceSelector{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

The `buildRequirements` function was skipping resources that did not have labels. It enabled filtering out labels set with `ValueFromFieldPath` that were empty and marked as Optional to be removed from the request.

To allow querying resources without setting label selectors, I added `hasOptionalSelector` boolean flag.

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #21 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
